### PR TITLE
Sluggify category link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,7 @@
                   <span class='divider'/>
                   <!-- link to page category if user is building categories -->
                   {% if config.generate_categories_pages %}
-                    <span><a href="/categories/{{page.category}}">{{ page.category }}</a></span>
+                    <span><a href="/categories/{{page.category | slugify }}">{{ page.category }}</a></span>
                   {% else %}
                     <span>{{ page.category }}</span>
                   {% endif %}


### PR DESCRIPTION
The current category link is works correctly for category names that are valid URLs, but breaks for category names that are invalid (for example, because they have a space).  Tera has a built in filter called "sluggify" that fixes this issue, which this commit adds.