### PR TITLE
Set HTML as "safe"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -47,7 +47,7 @@
                 <h3 class="title"> {{ page.title }} </h3>
               </a>
               <p> 
-                {{ page.content | striptags | truncate }} 
+                {{ page.content | safe | truncate }} 
               </p>
 
               <!-- TODO: modularize this so we don't repeat ourselves -->


### PR DESCRIPTION
This pull request suggests using the `safe` Tera filter to so that the HTML will display properly on the home page rather than having the home page display escaped HTML tags.