### PR TITLE
Add 'safe' filter to category.html and tag.html

### DIFF
--- a/templates/category.html
+++ b/templates/category.html
@@ -12,7 +12,7 @@
               <h3 class="title"> {{ page.title }} </h3>
             </a>
             <p> 
-              {{ page.content | striptags | truncate }} 
+              {{ page.content | safe | truncate }} 
             </p>
           </section>
         <hr/>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -12,7 +12,7 @@
               <h3 class="title"> {{ page.title }} </h3>
             </a>
             <p> 
-              {{ page.content | striptags | truncate }} 
+              {{ page.content | safe | truncate }} 
             </p>
           </section>
         <hr/>


### PR DESCRIPTION
I should have noticed this before: there are two other templates that also needed to use the `safe` filter, `category.html` and `tag.html`.  This pull request makes that change; sorry I didn't notice it before. 

This change mirrors the previous change to `index.html` and has the same effect—it causes the rendered HTML content to display instead of displaying the sanitized HTML tags.