### PR TITLE
Rename references to Gutenberg to point to Zola

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # feather
-A lightweight theme for gutenberg
+A lightweight theme for zola 
 
-Feather is a blog theme specifically designed for the static site generator [Gutenberg](https://github.com/Keats/gutenberg).  It's as far as 
+Feather is a blog theme specifically designed for the static site generator [Zola](https://www.getzola.org/).  It's as far as 
 I know the first theme for the platform that isn't a port or just contained within template files.  
 
 Feather is *not* intended for anything other than blogs.  
 
 # Developing & Contributing
 Because feather comes with example content, you can run the theme just like any Gutenberg
-blog with `gutenberg serve`.  Your changes will autoreload!
+blog with `zola serve`.  Your changes will autoreload!
 
 ## Considerations
 Please don't edit the `content` folder directly for your own blog, use it as a theme like
 intended!
 
 # Usage
-Using feather is easy.  Install [Gutenberg](https://github.com/Keats/gutenberg) and follow 
-[the guide for creating a site and using a theme](https://www.getgutenberg.io/documentation/themes/installing-and-using-themes/).  Then,
+Using feather is easy.  Install [Zola](https://www.getzola.org/) and follow 
+[the guide for creating a site and using a theme](https://www.getzola.org/documentation/themes/installing-and-using-themes/).  Then,
 add `theme = "feather"` to your `config.toml` file.
 
 If you intend to publish your site to Github Pages, please check out [this tutorial](http://vaporsoft.net/publishing-gutenberg-to-github/).
 
 ## Options
-Gutenberg allows themes to [define `[extra]` variables](https://www.getgutenberg.io/documentation/getting-started/configuration/)
+Zola allows themes to [define `[extra]` variables](https://www.getzola.org/documentation/getting-started/configuration/)
 in the config.  Here's a full list of theme variables with example values and comments.
 
 ```

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # This is an example file to help you get started.
-# This also lets you run `gutenberg serve` just in the themes directory
+# This also lets you run `zola serve` just in the themes directory
 # for easier development.
 
 # The URL the site will be built for

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,7 +75,7 @@
     {% endblock content %}
 
     <footer>
-      Feather theme by <a href="https://github.com/piedoom/feather">doomy</a>&nbsp;&nbsp;-&nbsp;&nbsp; Built with <a href="https://github.com/Keats/gutenberg">Gutenberg</a>
+      Feather theme by <a href="https://github.com/piedoom/feather">doomy</a>&nbsp;&nbsp;-&nbsp;&nbsp; Built with <a href="https://www.getzola.org/">Zola</a>
       {% if config.extra.feather_donate_link %}&nbsp;&nbsp;-&nbsp;&nbsp; <a href={{config.extra.feather_donate_link}}>Donate</a>
       {% endif %}
     </footer>


### PR DESCRIPTION
As Gutenberg was renamed to Zola recently, this refreshes the name and
URLs pointing to Gutenberg to point to Zola now.

Hope this helps.

thanks !